### PR TITLE
feat: 그룹 검색 및 가입 로직 개선

### DIFF
--- a/lib/controllers/group_controller.dart
+++ b/lib/controllers/group_controller.dart
@@ -3,11 +3,13 @@
 // class GroupController extends GetxController {
 //
 // }
+import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import '../models/group.dart';
 
 class GroupController extends GetxController {
   RxList<Group> groups = <Group>[].obs;
+  RxList<Group> filteredGroups = <Group>[].obs;
 
   @override
   void onInit() {
@@ -21,7 +23,13 @@ class GroupController extends GetxController {
         id: '1',
         name: '현장 프로젝트 2팀',
         description: '테스트 그룹입니다.',
-        memberStatus: '49/50명',
+        currentMembers: 49,
+        maxMembers: 50,
+        rules: [
+          '하루 커밋 횟수 7회 이하시 강퇴',
+          '랭킹 1등에게 Ing 쿠폰 제공',
+        ],
+        password: '1234',
         isActive: true,
       ),
       ...List.generate(5, (i) {
@@ -29,9 +37,59 @@ class GroupController extends GetxController {
           id: '${i + 2}',
           name: '테스트 그룹입니다.',
           description: '테스트 그룹입니다.',
-          memberStatus: '49/50명',
+          currentMembers: 48,
+          maxMembers: 50,
+          rules: [
+            '하루 커밋 1회 이상 필수',
+            '랭킹 3등까지 혜택 제공',
+          ],
+          password: '0000',
         );
       }),
     ];
+
+    // 기본 화면 - 그룹 전체 보이기
+    filteredGroups.value = groups;
   }
+
+  void searchGroup(String query) {
+    if (query.isEmpty) {
+      filteredGroups.value = groups;
+    } else {
+      filteredGroups.value = groups
+          .where((g) =>
+      g.name.contains(query) ||
+          g.description.contains(query))
+          .toList();
+    }
+  }
+
+  // 그룹 가입 시 비밀번호 확인 로직
+  bool verifyGroupPassword(Group group, String inputPassword) {
+    return group.password == inputPassword;
+  }
+
+  // 그룹 가입 성공 처리 (추후 서버 요청 등 추가 가능)
+  void joinGroup(Group group) {
+    final index = groups.indexWhere((g) => g.id == group.id);
+    if (index != -1 && groups[index].currentMembers < groups[index].maxMembers) {
+      final updated = groups[index].copyWith(
+        currentMembers: groups[index].currentMembers + 1,
+      );
+      groups[index] = updated;
+
+      // filteredGroups도 동기화
+      final fIndex = filteredGroups.indexWhere((g) => g.id == group.id);
+      if (fIndex != -1) {
+        filteredGroups[fIndex] = updated;
+      }
+
+      if (kDebugMode) {
+        print('[JOINED] ${updated.name} | ${updated.memberStatus}');
+      }
+    }
+  }
+
+
+
 }

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -2,14 +2,20 @@ class Group {
   final String id;
   final String name;
   final String description;
-  final String memberStatus;
+  final int currentMembers;
+  final int maxMembers;
+  final List<String> rules;
+  final String password;
   final bool isActive;
 
   Group({
     required this.id,
     required this.name,
     required this.description,
-    required this.memberStatus,
+    required this.currentMembers,
+    required this.maxMembers,
+    required this.rules,
+    required this.password,
     this.isActive = false,
   });
 
@@ -17,15 +23,23 @@ class Group {
     String? id,
     String? name,
     String? description,
-    String? memberStatus,
+    int? currentMembers,
+    int? maxMembers,
+    List<String>? rules,
+    String? password,
     bool? isActive,
   }) {
     return Group(
       id: id ?? this.id,
       name: name ?? this.name,
       description: description ?? this.description,
-      memberStatus: memberStatus ?? this.memberStatus,
+      currentMembers: currentMembers ?? this.currentMembers,
+      maxMembers: maxMembers ?? this.maxMembers,
+      rules: rules ?? this.rules,
+      password: password ?? this.password,
       isActive: isActive ?? this.isActive,
     );
   }
+
+  String get memberStatus => '$currentMembers/$maxMembers명';
 }

--- a/lib/views/group_search_view.dart
+++ b/lib/views/group_search_view.dart
@@ -1,8 +1,50 @@
+// import 'package:flutter/material.dart';
+// import 'package:get/get.dart';
+// import 'package:hugeicons/hugeicons.dart';
+//
+// import '../controllers/group_controller.dart';
+// import '../routes/app_route.dart';
+//
+// class GroupSearchView extends GetView<GroupController> {
+//   const GroupSearchView({super.key});
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//         appBar: AppBar(
+//           title: Text('그룹 검색'),
+//           centerTitle: true,
+//         ),
+//         body: Center(
+//           child: Text('그룹 검색'),
+//         ),
+//       floatingActionButton: FloatingActionButton(
+//         onPressed: () => Get.toNamed(AppRoutes.newGroup),
+//         backgroundColor: Colors.white,
+//         elevation: 0,
+//         highlightElevation: 0,
+//         disabledElevation: 0,
+//         shape: RoundedRectangleBorder(
+//           borderRadius: BorderRadius.circular(10),
+//           side: BorderSide(color: Color(0xffd9d9d9), width: 2),
+//         ),
+//         focusColor: Colors.white,
+//         focusElevation: 0,
+//         hoverColor: Colors.white,
+//         hoverElevation: 0,
+//         child: Icon(HugeIcons.strokeRoundedTaskAdd01, color: Colors.grey),
+//       ),
+//     );
+//   }
+//
+// }
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hugeicons/hugeicons.dart';
 
 import '../controllers/group_controller.dart';
+import '../models/group.dart';
 import '../routes/app_route.dart';
 
 class GroupSearchView extends GetView<GroupController> {
@@ -11,30 +53,269 @@ class GroupSearchView extends GetView<GroupController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Text('그룹 검색'),
-          centerTitle: true,
+      backgroundColor: const Color(0xfffafafa),
+      appBar: AppBar(
+        backgroundColor: const Color(0xfffafafa),
+        elevation: 0,
+        leading: const BackButton(color: Colors.black),
+        title: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: const [
+            Text(
+              '스터디 그룹 검색',
+              style: TextStyle(
+                color: Colors.black,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
-        body: Center(
-          child: Text('그룹 검색'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              "그룹을 검색해서\n스터디 그룹에 속해보세요.",
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 20),
+
+            // 검색 입력창
+            TextField(
+              onChanged: controller.searchGroup,
+              decoration: InputDecoration(
+                hintText: '그룹명을 입력하세요',
+                prefixIcon: const Icon(Icons.search),
+                filled: true,
+                fillColor: Colors.white,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                  borderSide: BorderSide.none,
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 20),
+
+            // 그룹 리스트
+            Expanded(
+              child: Obx(
+                () => ListView.separated(
+                  itemCount: controller.filteredGroups.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, index) {
+                    final group = controller.filteredGroups[index];
+                    return _buildGroupCard(group);
+                  },
+                ),
+              ),
+            ),
+          ],
         ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => Get.toNamed(AppRoutes.newGroup),
         backgroundColor: Colors.white,
         elevation: 0,
-        highlightElevation: 0,
-        disabledElevation: 0,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
-          side: BorderSide(color: Color(0xffd9d9d9), width: 2),
+          side: const BorderSide(color: Color(0xffd9d9d9), width: 2),
         ),
-        focusColor: Colors.white,
-        focusElevation: 0,
-        hoverColor: Colors.white,
-        hoverElevation: 0,
-        child: Icon(HugeIcons.strokeRoundedTaskAdd01, color: Colors.grey),
+        child: const Icon(HugeIcons.strokeRoundedTaskAdd01, color: Colors.grey),
       ),
     );
   }
 
+  void showGroupDetailDialog(BuildContext context, Group group) {
+    final TextEditingController passwordController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (_) {
+        return Dialog(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(30),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  group.name,
+                  style: const TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 20),
+
+                const Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '그룹 규칙',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                  ),
+                ),
+                const SizedBox(height: 8),
+
+                // 규칙 리스트
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children:
+                        group.rules
+                            .map(
+                              (rule) => Text(
+                                '• $rule',
+                                style: const TextStyle(color: Colors.grey),
+                              ),
+                            )
+                            .toList(),
+                  ),
+                ),
+
+                const SizedBox(height: 16),
+                Text(
+                  '인원 ${group.memberStatus}',
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 20),
+
+                // 비밀번호 입력 필드
+                TextField(
+                  controller: passwordController,
+                  decoration: InputDecoration(
+                    labelText: '비밀번호',
+                    hintText: '비밀번호를 입력하세요',
+                    filled: true,
+                    fillColor: const Color(0xFFF6F6F6),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(15),
+                      borderSide: BorderSide.none,
+                    ),
+                    labelStyle: const TextStyle(
+                      color: Color(0xffff8126),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+
+                // 버튼
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () => Navigator.pop(context),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.grey,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                        child: const Text('취소'),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () {
+                          final password = passwordController.text;
+                          final isValid = controller.verifyGroupPassword(group, password);
+
+                          if (isValid) {
+                            if (group.currentMembers >= group.maxMembers) {
+                              Get.snackbar('가입 실패', '정원이 초과된 그룹입니다',
+                                  snackPosition: SnackPosition.BOTTOM);
+                            } else {
+                              controller.joinGroup(group);
+                              Get.back();
+                              Get.snackbar('가입 성공', '${group.name}에 가입되었습니다!',
+                                  snackPosition: SnackPosition.BOTTOM);
+                            }
+                          } else {
+                            Get.snackbar('오류', '비밀번호가 올바르지 않습니다',
+                                snackPosition: SnackPosition.BOTTOM,
+                                backgroundColor: Colors.redAccent,
+                                colorText: Colors.white);
+                          }
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xffff8126),
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                        ),
+                        child: const Text('그룹 가입'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildGroupCard(Group group) {
+    return GestureDetector(
+      onTap: () => showGroupDetailDialog(Get.context!, group), // 팝업 띄우기
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 15),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x3F000000),
+              blurRadius: 10,
+              offset: Offset(2, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              group.name,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.black,
+              ),
+            ),
+            const SizedBox(height: 5),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  group.description,
+                  style: const TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+                Text(
+                  group.memberStatus,
+                  style: const TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
- Group 모델 구조 개선
  - memberStatus를 getter로 분리해 current/maxMembers 기반 자동 계산
  - rules(규칙), password(가입용), currentMembers(현재 인원) 필드 추가

- GroupController 기능 확장
  - searchGroup: 그룹명 또는 설명으로 실시간 필터링
  - verifyGroupPassword: 그룹 비밀번호 일치 여부 검증 로직 추가
  - joinGroup: 현재 인원 증가 및 filteredGroups와 동기화 처리

- GroupSearchView 개선
  - 그룹 카드 클릭 시 그룹 상세 Dialog 팝업 표시
  - 팝업 내 그룹 규칙, 비밀번호 입력, 가입 버튼 구현
  - 가입 성공 시 해당 그룹 currentMembers 자동 증가 및 UI 갱신