### PR TITLE
feat: 그룹 생성 및 검색 기능 UI/로직 통합 개선

### DIFF
--- a/lib/controllers/group_controller.dart
+++ b/lib/controllers/group_controller.dart
@@ -72,24 +72,58 @@ class GroupController extends GetxController {
   // 그룹 가입 성공 처리 (추후 서버 요청 등 추가 가능)
   void joinGroup(Group group) {
     final index = groups.indexWhere((g) => g.id == group.id);
-    if (index != -1 && groups[index].currentMembers < groups[index].maxMembers) {
-      final updated = groups[index].copyWith(
-        currentMembers: groups[index].currentMembers + 1,
-      );
-      groups[index] = updated;
 
-      // filteredGroups도 동기화
-      final fIndex = filteredGroups.indexWhere((g) => g.id == group.id);
-      if (fIndex != -1) {
-        filteredGroups[fIndex] = updated;
+    if (index != -1) {
+      final existing = groups[index];
+
+      //이미 가입된 그룹이면 리턴
+      if (existing.isActive) {
+        if (kDebugMode) {
+          print('[ALREADY JOINED] ${existing.name}');
+        }
+        return;
       }
 
-      if (kDebugMode) {
-        print('[JOINED] ${updated.name} | ${updated.memberStatus}');
+      if (existing.currentMembers < existing.maxMembers) {
+        final updated = existing.copyWith(
+          currentMembers: existing.currentMembers + 1,
+          isActive: true, //가입 상태 true로 변경
+        );
+        groups[index] = updated;
+
+        // filteredGroups도 동기화
+        final fIndex = filteredGroups.indexWhere((g) => g.id == group.id);
+        if (fIndex != -1) {
+          filteredGroups[fIndex] = updated;
+        }
+
+        if (kDebugMode) {
+          print('[JOINED] ${updated.name} | ${updated.memberStatus}');
+        }
       }
     }
   }
 
+  void addGroup({
+    required String name,
+    required String description,
+    required int maxMembers,
+    required List<String> rules,
+    required String password,
+  }) {
+    final newGroup = Group(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      name: name,
+      description: description,
+      maxMembers: maxMembers,
+      rules: rules,
+      password: password,
+      currentMembers: 1,
+      isActive: true,
+    );
 
+    groups.insert(0, newGroup);
+    searchGroup(''); // 검색어 초기화 → 전체 리스트 재필터링
+  }
 
 }

--- a/lib/views/group_add_view.dart
+++ b/lib/views/group_add_view.dart
@@ -1,3 +1,26 @@
+// import 'package:flutter/material.dart';
+// import 'package:get/get.dart';
+//
+// import '../controllers/group_controller.dart';
+//
+// class GroupAddView extends GetView<GroupController> {
+//   const GroupAddView({super.key});
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return Scaffold(
+//       appBar: AppBar(
+//         title: Text('그룹 추가'),
+//         centerTitle: true,
+//       ),
+//       body: Center(
+//         child: Text('그룹 추가'),
+//       )
+//     );
+//   }
+//
+// }
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -8,15 +31,202 @@ class GroupAddView extends GetView<GroupController> {
 
   @override
   Widget build(BuildContext context) {
+    final nameController = TextEditingController();
+    final descController = TextEditingController();
+    final maxController = TextEditingController();
+    final rulesController = TextEditingController();
+    final passwordController = TextEditingController();
+
     return Scaffold(
+      backgroundColor: const Color(0xfffafafa),
       appBar: AppBar(
-        title: Text('그룹 추가'),
+        backgroundColor: const Color(0xfffafafa),
+        elevation: 0,
+        leading: const BackButton(color: Colors.black),
+        title: const Text(
+          '그룹 만들기',
+          style: TextStyle(
+            color: Colors.black,
+            fontWeight: FontWeight.bold,
+            fontSize: 22,
+          ),
+        ),
         centerTitle: true,
       ),
-      body: Center(
-        child: Text('그룹 추가'),
-      )
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                "스터디 그룹을\n만들어주세요.",
+                style: TextStyle(
+                  fontSize: 25,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 20),
+              _buildCardField(label: '그룹명', controller: nameController),
+              const SizedBox(height: 16),
+              _buildCardField(label: '그룹 소개', controller: descController),
+              const SizedBox(height: 16),
+              _buildCardField(
+                label: '최대 인원',
+                controller: maxController,
+                inputType: TextInputType.number,
+              ),
+              const SizedBox(height: 16),
+              _buildCardField(
+                label: '그룹 규칙',
+                controller: rulesController,
+                maxLines: 6,
+                isMultiline: true,
+              ),
+              const SizedBox(height: 16),
+              _buildCardField(
+                label: '비밀 번호',
+                controller: passwordController,
+                obscureText: true,
+              ),
+              const SizedBox(height: 30),
+              Row(
+                children: [
+                  // 취소 버튼
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () => Get.back(),
+                      child: Container(
+                        height: 50,
+                        decoration: ShapeDecoration(
+                          color: const Color(0xFF868583),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                        ),
+                        child: const Center(
+                          child: Text(
+                            '취소',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 18,
+                              fontFamily: 'Pretendard Variable',
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  // 생성하기 버튼
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {
+                        controller.addGroup(
+                          name: nameController.text,
+                          description: descController.text,
+                          maxMembers: int.tryParse(maxController.text) ?? 50,
+                          rules: rulesController.text
+                              .split('\n')
+                              .map((e) => e.trim())
+                              .where((e) => e.isNotEmpty)
+                              .toList(),
+                          password: passwordController.text,
+                        );
+                        Get.back();
+                        Get.snackbar('성공', '그룹이 생성되었습니다');
+                      },
+                      child: Container(
+                        height: 50,
+                        decoration: ShapeDecoration(
+                          color: const Color(0xFFFF8126),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                        ),
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Icon(Icons.add_circle_outline, color: Colors.white),
+                            SizedBox(width: 5),
+                            Text(
+                              '생성하기',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 18,
+                                fontFamily: 'Pretendard Variable',
+                                fontWeight: FontWeight.w700,
+                                height: 1.67,
+                                letterSpacing: 1,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 
+  Widget _buildCardField({
+    required String label,
+    required TextEditingController controller,
+    TextInputType inputType = TextInputType.text,
+    int maxLines = 1,
+    bool obscureText = false,
+    bool isMultiline = false,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x3F000000),
+            blurRadius: 10,
+            offset: Offset(2, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              color: Color(0xffff8126),
+              fontWeight: FontWeight.w700,
+              fontSize: 16,
+              letterSpacing: -0.5,
+            ),
+          ),
+          const SizedBox(height: 4),
+          TextField(
+            controller: controller,
+            keyboardType: isMultiline ? TextInputType.multiline : inputType,
+            maxLines: isMultiline ? null : maxLines,
+            obscureText: obscureText,
+            decoration: const InputDecoration(
+              border: InputBorder.none,
+              hintText: '입력해주세요',
+              hintStyle: TextStyle(
+                color: Color(0xFF868583),
+                fontSize: 16,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/views/group_search_view.dart
+++ b/lib/views/group_search_view.dart
@@ -230,7 +230,9 @@ class GroupSearchView extends GetView<GroupController> {
                     const SizedBox(width: 10),
                     Expanded(
                       child: ElevatedButton(
-                        onPressed: () {
+                        onPressed: group.isActive
+                            ? null  // 이미 가입한 그룹은 비활성화
+                            : () {
                           final password = passwordController.text;
                           final isValid = controller.verifyGroupPassword(group, password);
 
@@ -252,14 +254,17 @@ class GroupSearchView extends GetView<GroupController> {
                           }
                         },
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xffff8126),
+                          backgroundColor: group.isActive ? Colors.grey.shade400 : const Color(0xffff8126),
                           foregroundColor: Colors.white,
                           padding: const EdgeInsets.symmetric(vertical: 14),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(10),
                           ),
                         ),
-                        child: const Text('그룹 가입'),
+                        child: Text(
+                          group.isActive ? '이미 가입한 그룹' : '그룹 가입',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
- 그룹명, 소개, 최대 인원, 규칙, 비밀번호 입력 필드 카드 UI 적용
- 그룹 규칙 멀티라인 TextField 구현 및 줄바꿈 가능하게 처리
- 생성하기 버튼에 add_circle_outline 아이콘 추가
- 생성 및 취소 버튼의 높이를 동일하게 조정
- Pretendard Variable 폰트와 컬러 스타일 적용
- 생성 성공 시 Get.snackbar 알림 추가

- 그룹 상세 팝업에 비밀번호 입력창 및 규칙 목록 표시
- 가입 버튼 클릭 시 비밀번호 검증 및 정원 초과 체크 로직 추가
- 이미 가입한 그룹 중복 가입 방지 로직 추가 예정 포인트 표시

- addGroup 함수에서 그룹 생성 시 필터링 리스트에도 자동 반영
- 줄바꿈 기반 그룹 규칙 파싱 로직 추가 (rules: split('\n'))
- 가입 시 currentMembers 증가 로직 반영 및 filteredGroups 동기화
- 기존 가입 여부 체크 및 중복 가입 방지 로직 추가 예정 포인트 주석 처리