### PR TITLE
feat: 로그인 UI 개선 및 Repo 모델 수정

### DIFF
--- a/lib/models/repo.dart
+++ b/lib/models/repo.dart
@@ -21,8 +21,8 @@ class Repo {
     return Repo(
       id: json['id'],
       title: json['title'],
-      subtitle: json['subTitle'],
-      repoAddress: json['repoAddress'],
+      subtitle: json['sub_title'],
+      repoAddress: json['repo_address'],
     );
   }
 

--- a/lib/views/login_view.dart
+++ b/lib/views/login_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:hugeicons/hugeicons.dart';
 
 import '../controllers/auth_controller.dart';
 import '../routes/app_route.dart';
@@ -10,18 +11,53 @@ class LoginView extends GetView<AuthController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
+      backgroundColor: Colors.white,
+      body: Container(
+        padding: EdgeInsets.all(40),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            TextField(
-              controller: controller.emailController,
-              decoration: InputDecoration(labelText: '이메일'),
+            Image.asset('logo/playstore-icon.png', width: 200, height: 200),
+            SizedBox(height: 20),
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Color(0xFFd9d9d9),
+                  width: 2,
+                ),
+                borderRadius: BorderRadius.circular(10),
+                color: Colors.white,
+              ),
+              child: TextField(
+                controller: controller.emailController,
+                decoration: InputDecoration(
+                  icon: Icon(HugeIcons.strokeRoundedUserCircle02, size: 30),
+                  labelText: '아이디 및 이메일',
+                  border: InputBorder.none,
+                ),
+              ),
             ),
-            TextField(
-              controller: controller.passwordController,
-              decoration: InputDecoration(labelText: '비밀번호'),
+            SizedBox(height: 20),
+            Container(
+              padding: EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Color(0xFFd9d9d9),
+                  width: 2,
+                ),
+                borderRadius: BorderRadius.circular(10),
+                color: Colors.white,
+              ),
+              child: TextField(
+                controller: controller.passwordController,
+                decoration: InputDecoration(
+                  icon: Icon(HugeIcons.strokeRoundedCircleLock01, size: 30),
+                  labelText: '비밀번호'
+                    ,border: InputBorder.none,),
+              ),
             ),
+            SizedBox(height: 20),
             Row(
               children: [
                 ElevatedButton(


### PR DESCRIPTION
- **LoginView:**
    - 배경색 흰색으로 변경
    - 로고 이미지 추가 (`logo/playstore-icon.png`)
    - 아이디/이메일 입력 필드 및 비밀번호 입력 필드 디자인 개선
        - `Container`로 감싸고 테두리, 배경색, 둥근 모서리 적용
        - 입력 필드 아이콘 추가 (사용자, 자물쇠) - `InputDecoration`의 `border`를 `InputBorder.none`으로 설정
    - 위젯 간 간격 추가 (`SizedBox`)
- **Repo 모델:**
    - `fromJson` 팩토리 메소드에서 JSON 키 `subTitle`을 `sub_title`로, `repoAddress`를 `repo_address`로 수정