### PR TITLE
feat: 사용자 ID 저장 및 API 연동 개선

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -48,9 +48,15 @@ class AuthController extends GetxController {
     final email = emailController.text;
     final password = passwordController.text;
     final token = await authService.login(email, password);
-    await tokenService.saveToken(token);
-    isLoggedIn.value = true;
-    Get.offAllNamed(AppRoutes.home);
+    if (token.isEmpty) {
+      return;
+    }
+    else{
+      print('login success');
+      await tokenService.saveToken(token);
+      isLoggedIn.value = true;
+      Get.offAllNamed(AppRoutes.home);
+    }
   }
 
   Future<void> logout() async {

--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:http/http.dart' as http;
 
 import '../models/commit.dart';
 import '../models/repo.dart';
@@ -41,6 +42,8 @@ class HomeController extends GetxController {
   onInit() {
     super.onInit();
     fetchMockRepo();
+    fetchMockCommit(repos[0]);
+    fetchRepo();
   }
 
   @override
@@ -80,6 +83,17 @@ class HomeController extends GetxController {
       ),
     ];
   }
+  Future<void> fetchRepo() async {
+    final token = await tokenService.getToken();
+
+    final response = await http.get(
+      Uri.parse('http://15.164.49.227:8080/main?account_id=${token.username}'),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    );
+    print("${response.statusCode} ${response.body}");
+  }
 
   Future<void> fetchMockCommit(Repo repo) async {
     await Future.delayed(Duration(seconds: 1));
@@ -98,6 +112,12 @@ class HomeController extends GetxController {
     final repoDescription = repoDescriptionController.text.trim();
     final repoAddress = repoAddressController.text.trim();
     if (repoTitle.isEmpty || repoDescription.isEmpty || repoAddress.isEmpty) {
+      final response = await http.post(
+        Uri.parse('http://15.164.49.227:8080/main'),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      );
       Get.toNamed(AppRoutes.home);
       return;
     }

--- a/lib/models/token.dart
+++ b/lib/models/token.dart
@@ -2,32 +2,35 @@ class Token {
   final String gitToken;
   final String accessToken;
   final String refreshToken;
+  final String username;
 
-  Token(this.gitToken, this.accessToken, this.refreshToken);
+  Token(this.gitToken, this.accessToken, this.refreshToken, this.username);
 
   factory Token.fromJson(Map<String, dynamic> json) {
-    return Token(json['gitToken'], json['accessToken'], json['refreshToken']);
+    return Token(json['gitToken'], json['accessToken'], json['refreshToken'], json['username']);
   }
 
   factory Token.empty() {
-    return Token('', '', '');
+    return Token('', '', '', '');
   }
 
-  factory Token.testLogin() {
-    return Token('1234', '1234', '1234');
+  factory Token.testLogin(String userId) {
+    return Token('1234', '1234', '1234', userId);
   }
 
   Token copyWith({
     String? gitToken,
     String? accessToken,
     String? refreshToken,
+    String? username,
   }) {
     return Token(
       gitToken ?? this.gitToken,
       accessToken ?? this.accessToken,
       refreshToken ?? this.refreshToken,
+      username ?? this.username,
     );
   }
 
-  bool get isEmpty => gitToken == '' && accessToken == '' && refreshToken == '';
+  bool get isEmpty => gitToken == '' && accessToken == '' && refreshToken == '' && username == '';
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -9,15 +9,26 @@ import '../models/token.dart';
 
 class AuthService extends GetxService {
   Future<Token> login(String email, String password) async {
+    print('login start $email $password');
     final request = await http.post(
-      Uri.parse('/login'),
-      body: {'email': email, 'password': password},
+      Uri.parse('http://15.164.49.227:8080/user/login'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'accountId': email,
+        'password': password,
+      }),
     );
+    print("request.statusCode: ${request.statusCode} request.body: ${request.body}");
     if (request.statusCode == 200) {
-      final token = Token.fromJson(json.decode(request.body));
+      print(request.body);
+      final userId = json.decode(request.body)['id'];
+      final token = Token.testLogin(userId);
+
+      print('login success');
       return token;
     } else {
-      return Token.testLogin();
+      print('login fail');
+      return Token.empty();
       // throw Exception('Failed to login');
     }
   }

--- a/lib/services/token_service.dart
+++ b/lib/services/token_service.dart
@@ -11,21 +11,25 @@ class TokenService extends GetxService {
   static const _gitTokenKey = 'gitToken';
   static const _accessTokenKey = 'accessToken';
   static const _refreshTokenKey = 'refreshToken';
+  static const _usernameKey = 'username';
+
 
   Future<void> saveToken(Token token) async {
     await _storage.write(key: _gitTokenKey, value: token.gitToken);
     await _storage.write(key: _accessTokenKey, value: token.accessToken);
     await _storage.write(key: _refreshTokenKey, value: token.refreshToken);
+    await _storage.write(key: _usernameKey, value: token.username);
   }
 
   Future<Token> getToken() async {
     final gitToken = await _storage.read(key: _gitTokenKey);
     final accessToken = await _storage.read(key: _accessTokenKey);
     final refreshToken = await _storage.read(key: _refreshTokenKey);
+    final username = await _storage.read(key: _usernameKey);
 
-    if (gitToken != null && accessToken != null && refreshToken != null) {
+    if (gitToken != null && accessToken != null && refreshToken != null && username != null) {
       print("we call token service: $gitToken");
-      return Token(gitToken, accessToken, refreshToken);
+      return Token(gitToken, accessToken, refreshToken, username);
     } else {
       print('토큰이 없습니다.');
       return Token.empty();
@@ -36,9 +40,17 @@ class TokenService extends GetxService {
     await _storage.delete(key: _gitTokenKey);
     await _storage.delete(key: _accessTokenKey);
     await _storage.delete(key: _refreshTokenKey);
+    await _storage.delete(key: _usernameKey);
   }
 
   Future<void> saveGithubToken(String githubToken) async {
     await _storage.write(key: _gitTokenKey, value: githubToken);
+  }
+  Future<void> saveUsername(String username) async {
+    await _storage.write(key: _usernameKey, value: username);
+  }
+  Future<String> getUsername() async {
+    final username = await _storage.read(key: _usernameKey);
+    return username ?? '';
   }
 }


### PR DESCRIPTION
- **Token 모델 업데이트:**
    - `username` 필드 추가
    - `fromJson`, `empty`, `testLogin`, `copyWith` 메소드에 `username` 반영
    - `isEmpty` getter에 `username` 조건 추가
- **AuthController:**
    - 로그인 성공 시 사용자 ID를 포함한 토큰 저장
    - 로그인 실패 시 토큰을 저장하지 않고 반환
- **HomeController:**
    - `fetchRepo` 함수 추가: 사용자 ID를 사용하여 레포지토리 정보 요청
    - `addRepo` 함수에 레포지토리 추가 API 호출 로직 추가 (현재는 주석 처리)
    - `onInit` 시 `fetchRepo` 호출 추가
- **TokenService:**
    - `_usernameKey` 상수 추가
    - `saveToken`, `getToken`, `deleteToken` 메소드에 사용자 ID 저장/로드/삭제 로직 추가
    - `saveUsername` 및 `getUsername` 함수 추가
- **AuthService:**
    - `login` 함수: - API 엔드포인트 수정 (`http://15.164.49.227:8080/user/login`) - 요청 바디에 `accountId` 및 `password` 사용 - 로그인 성공 시 응답에서 사용자 ID (`id`) 추출하여 `Token.testLogin`에 전달 - 로그인 실패 시 `Token.empty()` 반환