### PR TITLE
refactor: 로그인 및 Repo 생성 API 연동 및 로직 수정

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -48,7 +48,8 @@ class AuthController extends GetxController {
     final email = emailController.text;
     final password = passwordController.text;
     final token = await authService.login(email, password);
-    if (token.isEmpty) {
+    final isAuth = await authService.checkAuth(token);
+    if (!isAuth) {
       return;
     }
     else{

--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
@@ -87,7 +88,8 @@ class HomeController extends GetxController {
     final token = await tokenService.getToken();
 
     final response = await http.get(
-      Uri.parse('http://15.164.49.227:8080/main?account_id=${token.username}'),
+      // Uri.parse('http://15.164.49.227:8080/main?account_id=${token.username}'),
+      Uri.parse('http://15.164.49.227:8080/planner/list'),
       headers: {
         'Content-Type': 'application/json',
       },
@@ -108,16 +110,30 @@ class HomeController extends GetxController {
   Future<void> makeNewRepo() async {
     // repoTitleController, repoDescriptionController, repoAddressController 내용을 가지고 fetch 작업을 할거임.
     await Future.delayed(Duration(seconds: 1));
-    final repoTitle = repoTitleController.text.trim();
-    final repoDescription = repoDescriptionController.text.trim();
-    final repoAddress = repoAddressController.text.trim();
-    if (repoTitle.isEmpty || repoDescription.isEmpty || repoAddress.isEmpty) {
+    final repoTitle = repoTitleController.text;
+    final repoDescription = repoDescriptionController.text;
+    final repoAddress = repoAddressController.text;
+    final username = await tokenService.getUsername();
+    print({
+      'user_id': username,
+      'name': repoTitle,
+      'description': repoDescription,
+      'repository_link': repoAddress,
+    });
+    if (repoTitle.isNotEmpty && repoDescription.isNotEmpty && repoAddress.isNotEmpty && gitAddressApproved.value) {
       final response = await http.post(
-        Uri.parse('http://15.164.49.227:8080/main'),
+        Uri.parse('http://15.164.49.227:8080/planner/create'),
         headers: {
           'Content-Type': 'application/json',
         },
+        body: jsonEncode({
+          'user_id': username,
+          'name': repoTitle,
+          'description': repoDescription,
+          'repository_link': repoAddress,
+        })
       );
+      print("${response.statusCode} ${response.body}");
       Get.toNamed(AppRoutes.home);
       return;
     }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -13,25 +13,29 @@ class AuthService extends GetxService {
     final request = await http.post(
       Uri.parse('http://15.164.49.227:8080/user/login'),
       headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({
-        'accountId': email,
-        'password': password,
-      }),
+      body: jsonEncode({'accountId': email, 'password': password}),
     );
-    print("request.statusCode: ${request.statusCode} request.body: ${request.body}");
+    print(
+      "request.statusCode: ${request.statusCode} request.body: ${request.body}",
+    );
     if (request.statusCode == 200) {
       print(request.body);
       final userId = json.decode(request.body)['id'];
       final token = Token.testLogin(userId);
-
-      print('login success');
-      return token;
+      if (userId == '') {
+        print('login fail');
+        return Token.empty();
+      } else {
+        print('login success');
+        return token;
+      }
     } else {
       print('login fail');
       return Token.empty();
       // throw Exception('Failed to login');
     }
   }
+
   Future<bool> checkAuth(Token token) async {
     return !token.isEmpty;
   }


### PR DESCRIPTION
- **AuthController:**
    - 로그인 시 `authService.checkAuth`를 호출하여 인증 상태를 확인하고, 인증 실패 시 추가 진행을 막도록 수정
- **HomeController:**
    - `fetchMockRepos` 함수에서 Repo 목록 조회 API 엔드포인트를 `/planner/list`로 변경
    - `makeNewRepo` 함수:
        - Repo 생성 API 엔드포인트를 `/planner/create`로 변경
        - 요청 바디에 `user_id`, `name`, `description`, `repository_link`를 포함하도록 수정 - Repo 주소 유효성 검사 (`gitAddressApproved.value`) 추가 - API 요청 및 응답 로그 추가
- **AuthService:**
    - `login` 함수에서 사용자 ID (`userId`)가 비어있는 경우 로그인 실패로 처리하고 빈 토큰을 반환하도록 수정