### PR TITLE
feat: 커밋 목록 표시 및 레포 검증 기능 추가

### DIFF
--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -26,6 +26,8 @@ class HomeController extends GetxController {
   RxList<Commit> commits = <Commit>[].obs;
 
   RxnString activeRepoId = RxnString(null);
+  RxnString activeRepoAddress = RxnString(null);
+  final RxString repoValidationMessage = ''.obs; // 오류 메시지용
   final Rx<DateTime> currentTime = DateTime.now().obs;
 
   Timer? _timer;
@@ -45,6 +47,7 @@ class HomeController extends GetxController {
     fetchMockRepo();
     fetchMockCommit(repos[0]);
     fetchRepo();
+
   }
 
   @override
@@ -72,7 +75,7 @@ class HomeController extends GetxController {
         id: '1',
         title: 'Repo 1',
         subtitle: 'Sub Title 1',
-        repoAddress: 'Address 1',
+        repoAddress: 'https://github.com/GitPumTa/FE',
         duration: Duration(seconds: 10),
       ),
       Repo(
@@ -88,8 +91,8 @@ class HomeController extends GetxController {
     final token = await tokenService.getToken();
 
     final response = await http.get(
-      // Uri.parse('http://15.164.49.227:8080/main?account_id=${token.username}'),
-      Uri.parse('http://15.164.49.227:8080/planner/list'),
+      Uri.parse('http://15.164.49.227:8080/main?account_id=${token.username}'),
+      // Uri.parse('http://15.164.49.227:8080/ranking/user'),
       headers: {
         'Content-Type': 'application/json',
       },
@@ -101,10 +104,67 @@ class HomeController extends GetxController {
     await Future.delayed(Duration(seconds: 1));
     // repo의 git address 로 api 요청 및, commit 리스트 반환, 갯수 반환 및 타이머 실행동안 커밋 수 확인 및 리더보드 등록 요청 보내기.
     commits.value = [
-      Commit(id: '1', message: 'Commit 1'),
-      Commit(id: '2', message: 'Commit 2'),
+      Commit(date: DateTime.now(), message: 'Commit 1'),
+      Commit(date: DateTime.now(), message: 'Commit 2'),
     ];
 
+  }
+
+  Future<void> fetchRowCommit(String address) async {
+    final gitToken = await tokenService.getGithubToken();
+    final username = await tokenService.getUsername();
+
+    final response = await http.get(
+      // Uri.parse('https://api.github.com/repos/tesupark/lifesam_random_pop/commits'),
+      Uri.parse('https://api.github.com/user'),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $gitToken',
+      },
+    );
+    final body = jsonDecode(response.body);
+    final name = body['name'];
+    final repoUrl = convertGitHubUrlToApi(address);
+    final commitResponse = await http.get(
+      Uri.parse(repoUrl),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $gitToken',
+      },
+    );
+    if (commitResponse.statusCode != 200) {
+      print('❌ Error: ${commitResponse.statusCode}');
+      return;
+    }
+
+    final List<dynamic> commitsJson = jsonDecode(commitResponse.body);
+
+    // Clear old data
+    commits.clear();
+
+    for (final item in commitsJson) {
+      final authorName = item['commit']['author']['name'];
+      final commit = Commit.fromJson(item);
+      final commitDate = commit.date.toLocal();
+
+      final now = DateTime.now();
+      final isToday = commitDate.year == now.year &&
+          commitDate.month == now.month &&
+          commitDate.day == now.day;
+
+      if (authorName == name && isToday) {
+        commits.add(commit);
+      }
+    }
+    var commission;
+    print("${commits.length}개의 커밋");
+    for (commission in commits) {
+      print(shortenText(commission.message,20));
+      print(commission.date);
+      print('-------');
+    }
+
+    // repo의 git address 로 api 요청 및, commit 리스트 반환, 갯수 반환 및 타이머 실행동안 커밋 수 확인 및 리더보드 등록 요청 보내기.
   }
 
   Future<void> makeNewRepo() async {
@@ -133,7 +193,11 @@ class HomeController extends GetxController {
           'repository_link': repoAddress,
         })
       );
-      print("${response.statusCode} ${response.body}");
+      repoTitleController.clear();
+      repoDescriptionController.clear();
+      repoAddressController.clear();
+      gitAddressApproved.value = false;
+      repoValidationMessage.value = '';
       Get.toNamed(AppRoutes.home);
       return;
     }
@@ -144,9 +208,27 @@ class HomeController extends GetxController {
   }
 
   Future<void> approveRepoAddress() async {
-    // repoAddressController 내용을 가지고 fetch 작업을 할거임. 검증이 완료되면 repoAddressController 에 해당하는 TextField입력을 막을것임.
-    await Future.delayed(Duration(seconds: 1));
-    gitAddressApproved.value = true;
+    final address = repoAddressController.text.trim();
+
+    // 빈 값 검증
+    if (address.isEmpty) {
+      repoValidationMessage.value = '주소를 입력해주세요.';
+      return;
+    }
+
+    repoValidationMessage.value = '검사 중...';
+
+    final exists = await checkRepoExists(address);
+
+    if (exists) {
+      gitAddressApproved.value = true;
+      repoValidationMessage.value = '✅ 유효한 레포입니다.';
+      print('✅ 유효한 레포입니다.');
+    } else {
+      gitAddressApproved.value = false;
+      repoValidationMessage.value = '❌ 존재하지 않는 레포입니다.';
+      print('❌ 존재하지 않는 레포입니다.');
+    }
   }
 
 
@@ -165,7 +247,9 @@ class HomeController extends GetxController {
     activeRepoId = RxnString(repoId);
     final index = repos.indexWhere((r) => r.id == repoId);
     if (index == -1) return;
-
+    activeRepoAddress = RxnString(repos[index].repoAddress);
+    final address = repos[index].repoAddress;
+    fetchRowCommit(address);
     repos[index] = repos[index].copyWith(status: TimerStatus.running);
     repos.refresh();
     _timer = Timer.periodic(Duration(seconds: 1), (_) {
@@ -244,4 +328,61 @@ class HomeController extends GetxController {
     final day = dateTime.day.toString().padLeft(2, '0');
     return '$year.$month.$day';
   }
+
+  String convertGitHubUrlToApi(String url) {
+    // .git 제거
+    if (url.endsWith('.git')) {
+      url = url.substring(0, url.length - 4);
+    }
+
+    // Uri 파싱
+    final uri = Uri.parse(url);
+
+    // 유효성 검사
+    if (uri.host != 'github.com') {
+      throw FormatException('올바른 GitHub URL이 아닙니다.');
+    }
+
+    // 경로에서 owner/repo 추출
+    final segments = uri.pathSegments;
+    if (segments.length < 2) {
+      throw FormatException('URL 경로가 너무 짧습니다. (예: /owner/repo)');
+    }
+
+    final owner = segments[0];
+    final repo = segments[1];
+
+    return 'https://api.github.com/repos/$owner/$repo/commits';
+  }
+  String shortenText(String text, int maxLength) {
+    if (text.length <= maxLength) return text;
+    return '${text.substring(0, maxLength)}...';
+  }
+
+  Future<bool> checkRepoExists(String url, {String? token}) async {
+    // .git 제거
+    if (url.endsWith('.git')) {
+      url = url.substring(0, url.length - 4);
+    }
+
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.host != 'github.com') return false;
+
+    final segments = uri.pathSegments;
+    if (segments.length < 2) return false;
+
+    final owner = segments[0];
+    final repo = segments[1];
+    final apiUrl = 'https://api.github.com/repos/$owner/$repo';
+
+    final response = await http.get(
+      Uri.parse(apiUrl),
+      headers: token != null
+          ? {'Authorization': 'Bearer $token'}
+          : {},
+    );
+
+    return response.statusCode == 200;
+  }
+
 }

--- a/lib/models/commit.dart
+++ b/lib/models/commit.dart
@@ -1,17 +1,17 @@
 class Commit {
-  final String id;
+  final DateTime date;
   final String message;
 
-  Commit({required this.id, required this.message});
+  Commit({required this.date, required this.message});
 
   factory Commit.fromJson(Map<String, dynamic> json) {
     return Commit(
-      id: json['id'],
-      message: json['message'],
+      message: json['commit']['message'] ?? '',
+      date: DateTime.parse(json['commit']['author']['date']),
     );
   }
 
   factory Commit.empty() {
-    return Commit(id: '', message: '');
+    return Commit(date: DateTime.now(), message: '');
   }
 }

--- a/lib/services/token_service.dart
+++ b/lib/services/token_service.dart
@@ -28,7 +28,6 @@ class TokenService extends GetxService {
     final username = await _storage.read(key: _usernameKey);
 
     if (gitToken != null && accessToken != null && refreshToken != null && username != null) {
-      print("we call token service: $gitToken");
       return Token(gitToken, accessToken, refreshToken, username);
     } else {
       print('토큰이 없습니다.');
@@ -52,5 +51,10 @@ class TokenService extends GetxService {
   Future<String> getUsername() async {
     final username = await _storage.read(key: _usernameKey);
     return username ?? '';
+  }
+
+  Future<String> getGithubToken() async {
+    final gitToken = await _storage.read(key: _gitTokenKey);
+    return gitToken ?? '';
   }
 }

--- a/lib/views/home_timer_view.dart
+++ b/lib/views/home_timer_view.dart
@@ -121,10 +121,9 @@ class HomeTimerView extends GetView<HomeController> {
           ),
           SizedBox(height: 20),
           Obx(() {
-
             final activeId = controller.activeRepoId.value;
             final repo = controller.repos.firstWhereOrNull(
-                  (r) => r.id == activeId,
+              (r) => r.id == activeId,
             );
 
             final isInactive = repo == null;
@@ -133,7 +132,10 @@ class HomeTimerView extends GetView<HomeController> {
             return ElevatedButton(
               onPressed: () => Get.toNamed(AppRoutes.newRepo),
               style: ElevatedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 10,
+                ),
                 elevation: 0,
                 backgroundColor: const Color(0xffFF8126),
                 foregroundColor: Colors.white,
@@ -161,7 +163,46 @@ class HomeTimerView extends GetView<HomeController> {
                 ],
               ),
             );
-          })
+          }),
+          SizedBox(height: 20),
+          Obx(() {
+            final commits = controller.commits;
+            return Container(
+              margin: EdgeInsets.symmetric(horizontal: 0, vertical: 5),
+              padding: EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(20),
+                boxShadow: [
+                  BoxShadow(
+                    color: Color(0x22000000),
+                    blurRadius: 10,
+                    offset: Offset(2, 2),
+                  ),
+                ],
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    '${commits.length}개의 커밋',
+                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                  IconButton(onPressed: () => controller.fetchRowCommit(controller.activeRepoAddress.value!), icon: Icon(HugeIcons.strokeRoundedRefresh)),
+                  SizedBox(height: 10),
+                  ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: commits.length,
+                    itemBuilder: (context, index) {
+                      final commit = commits[index];
+                      return ListTile(
+                        title: Text(controller.shortenText(commit.message, 50)),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            );
+          }),
         ],
       ),
     );


### PR DESCRIPTION
- **HomeController:**
    - `fetchRowCommit(address)` 함수 추가: GitHub API를 사용하여 특정 레포의 오늘자 커밋 목록을 가져와 `commits` 상태에 저장.
    - `approveRepoAddress()` 함수 개선: 입력된 GitHub 레포 주소의 유효성을 검사하고 결과를 `repoValidationMessage`에 표시. `checkRepoExists` 함수를 사용하여 실제 GitHub API를 호출하여 레포 존재 여부 확인.
    - `makeNewRepo()` 함수 수정: 새 레포 생성 후 입력 필드 초기화 및 `gitAddressApproved` 상태 초기화.
    - `convertGitHubUrlToApi(url)` 함수 추가: 일반 GitHub URL을 API 호출용 URL로 변환.
    - `shortenText(text, maxLength)` 함수 추가: 텍스트를 지정된 길이로 줄임.
    - `activeRepoAddress` 상태 추가: 현재 활성화된 레포의 주소를 저장.
    - 타이머 시작 시(`startTimer`) 현재 활성화된 레포의 커밋 목록을 가져오도록 수정.
- **HomeTimerView:**
    - 현재 활성화된 레포의 커밋 목록을 표시하는 UI 추가. - 커밋 개수 및 각 커밋 메시지 (축약형) 표시. - 새로고침 버튼으로 커밋 목록을 다시 가져올 수 있는 기능 추가.
- **TokenService:**
    - `getGithubToken()` 함수 추가: 저장된 GitHub 토큰을 반환.
- **Commit 모델:**
    - `id` 필드를 `date` (DateTime) 필드로 변경하여 커밋 날짜를 저장.
    - `fromJson` 팩토리 메서드 수정: API 응답에서 커밋 메시지 및 날짜를 파싱하도록 변경.